### PR TITLE
chore(clippy): run Clippy on codebase

### DIFF
--- a/bestool/src/beslink/bootloader.rs
+++ b/bestool/src/beslink/bootloader.rs
@@ -4,10 +4,10 @@ use std::io::Write;
 use tracing::error;
 use tracing::info;
 //Embed the bin file for future
-const PROGRAMMER_BINARY: &'static [u8; 75928] = include_bytes!("../../../programmer.bin");
+const PROGRAMMER_BINARY: &[u8; 75928] = include_bytes!("../../../programmer.bin");
 
 pub fn load_programmer_runtime_binary_blob(
-    mut serial_port: &mut Box<dyn SerialPort>,
+    serial_port: &mut Box<dyn SerialPort>,
 ) -> Result<(), BESLinkError> {
     let preload_setup_message = BesMessage {
         sync: BES_SYNC,
@@ -21,7 +21,7 @@ pub fn load_programmer_runtime_binary_blob(
         checksum: 0x4A,
     };
     info!("Start Message {:X?}", preload_setup_message.to_vec());
-    send_message(&mut serial_port, preload_setup_message)?;
+    send_message(serial_port, preload_setup_message)?;
     let response = sync(serial_port, MessageTypes::StartProgrammer)?;
     if response.payload[0] != 0x00 {
         return Err(BESLinkError::BadResponseCode {
@@ -39,7 +39,7 @@ pub fn load_programmer_runtime_binary_blob(
         ],
         checksum: 0x00,
     };
-    send_message(&mut serial_port, programmer_leader)?;
+    send_message(serial_port, programmer_leader)?;
     match serial_port.write_all(&PROGRAMMER_BINARY[0x428..PROGRAMMER_BINARY.len() - 4]) {
         Ok(_) => {}
         Err(e) => {
@@ -56,10 +56,10 @@ pub fn load_programmer_runtime_binary_blob(
         });
     }
 
-    return Ok(());
+    Ok(())
 }
 pub fn start_programmer_runtime_binary_blob(
-    mut serial_port: &mut Box<dyn SerialPort>,
+    serial_port: &mut Box<dyn SerialPort>,
 ) -> Result<BesMessage, BESLinkError> {
     let preload_setup_message = BesMessage {
         sync: BES_SYNC,
@@ -67,7 +67,7 @@ pub fn start_programmer_runtime_binary_blob(
         payload: vec![0x01, 0x00],
         checksum: 0xEB,
     };
-    send_message(&mut serial_port, preload_setup_message)?;
+    send_message(serial_port, preload_setup_message)?;
     info!("Sent start programmer message");
     let resp = sync(serial_port, MessageTypes::ProgrammerInit)?;
     if resp.payload != vec![0x00, 0x06, 0x03, 0x01, 0x00, 0x90, 0x00, 0x00] {
@@ -77,5 +77,5 @@ pub fn start_programmer_runtime_binary_blob(
             wanted: 0x0,
         });
     }
-    return Ok(resp);
+    Ok(resp)
 }

--- a/bestool/src/beslink/helper_sync_and_load_programmer.rs
+++ b/bestool/src/beslink/helper_sync_and_load_programmer.rs
@@ -17,7 +17,7 @@ pub fn helper_sync_and_load_programmer(
     info!("Started programmer blob");
     query_memory_info(serial_port)?;
     info!("Got Memory info Done; so programmer blob is working");
-    return Ok(());
+    Ok(())
 }
 fn get_stay_in_programmer_message() -> BesMessage {
     BesMessage {

--- a/bestool/src/beslink/memory_info.rs
+++ b/bestool/src/beslink/memory_info.rs
@@ -14,11 +14,11 @@ pub fn query_memory_info(serial_port: &mut Box<dyn SerialPort>) -> Result<(), BE
         payload: vec![0x03, 0x01, 0x12],
         checksum: 0xC6,
     };
-    let _ = send_message(serial_port, get_flash_id_cmd)?;
+    send_message(serial_port, get_flash_id_cmd)?;
     let flash_id = sync(serial_port, MessageTypes::FlashCommand)?;
-    let _ = send_message(serial_port, get_flash_unique_id_cmd)?;
+    send_message(serial_port, get_flash_unique_id_cmd)?;
     let flash_unique_id = sync(serial_port, MessageTypes::FlashCommand)?;
     println!("Flash General ID {:?}", flash_id.payload);
     println!("Flash Unique ID {:?}", flash_unique_id.payload);
-    return Ok(());
+    Ok(())
 }

--- a/bestool/src/beslink/mod.rs
+++ b/bestool/src/beslink/mod.rs
@@ -9,7 +9,7 @@ mod sync;
 mod test_port;
 mod write_flash;
 
-pub const BES_PROGRAMMING_BAUDRATE: u32 = 921600;
+pub const BES_PROGRAMMING_BAUDRATE: u32 = 921_600;
 pub const BES_SYNC: u8 = 0xBE;
 pub const FLASH_BUFFER_SIZE: usize = 0x8000;
 

--- a/bestool/src/beslink/read_flash.rs
+++ b/bestool/src/beslink/read_flash.rs
@@ -35,7 +35,7 @@ pub fn read_flash_data(
         }
     }
     result.resize(length, 0xFF);
-    return Ok(result);
+    Ok(result)
 }
 
 //
@@ -57,6 +57,6 @@ fn read_flash_chunk(
 
     send_message(serial_port, cfg_data_1)?;
     //response is 4102 bytes total = 4096 (0x1000)
-    let (_, payload) = read_message_with_trailing_data(serial_port, chunk_size as usize)?;
-    return Ok(payload);
+    let (_, payload) = read_message_with_trailing_data(serial_port, chunk_size)?;
+    Ok(payload)
 }

--- a/bestool/src/beslink/reboot.rs
+++ b/bestool/src/beslink/reboot.rs
@@ -25,5 +25,5 @@ pub fn send_device_reboot(
         device_reboot_message.to_vec()
     );
     send_message(serial_port, device_reboot_message)?;
-    return sync(serial_port, MessageTypes::DeviceCommand);
+    sync(serial_port, MessageTypes::DeviceCommand)
 }

--- a/bestool/src/beslink/test_port.rs
+++ b/bestool/src/beslink/test_port.rs
@@ -29,36 +29,36 @@ mod tests {
 
     impl SerialPort for FakeSerialPort {
         fn name(&self) -> Option<String> {
-            return Some("Faux".to_owned());
+            Some("Faux".to_owned())
         }
 
         fn baud_rate(&self) -> serialport::Result<u32> {
-            return Ok(BES_PROGRAMMING_BAUDRATE);
+            Ok(BES_PROGRAMMING_BAUDRATE)
         }
 
         fn data_bits(&self) -> serialport::Result<DataBits> {
-            return Ok(DataBits::Eight);
+            Ok(DataBits::Eight)
         }
 
         fn flow_control(&self) -> serialport::Result<FlowControl> {
-            return Ok(FlowControl::None);
+            Ok(FlowControl::None)
         }
 
         fn parity(&self) -> serialport::Result<Parity> {
-            return Ok(Parity::None);
+            Ok(Parity::None)
         }
 
         fn stop_bits(&self) -> serialport::Result<StopBits> {
-            return Ok(StopBits::One);
+            Ok(StopBits::One)
         }
 
         fn timeout(&self) -> Duration {
-            return Duration::from_millis(1000);
+            Duration::from_millis(1000)
         }
 
         fn set_baud_rate(&mut self, baud_rate: u32) -> serialport::Result<()> {
             self.baud = baud_rate;
-            return Ok(());
+            Ok(())
         }
 
         fn set_data_bits(&mut self, _data_bits: DataBits) -> serialport::Result<()> {

--- a/bestool/src/beslink/write_flash.rs
+++ b/bestool/src/beslink/write_flash.rs
@@ -14,7 +14,7 @@ pub fn burn_image_to_flash(
     payload_in: Vec<u8>,
     address: usize,
 ) -> Result<(), BESLinkError> {
-    let mut payload = payload_in.clone();
+    let mut payload = payload_in;
     //Pad image to FLASH_BUFFER_SIZE
     while payload.len() % FLASH_BUFFER_SIZE != 0 {
         payload.push(0xFF);
@@ -75,7 +75,7 @@ pub fn burn_image_to_flash(
         }
     }
     info!("Sending flash finalise");
-    return send_flash_commit_message(serial_port, address);
+    send_flash_commit_message(serial_port, address)
 }
 fn send_flash_commit_message(
     serial_port: &mut Box<dyn SerialPort>,
@@ -105,7 +105,7 @@ fn send_flash_commit_message(
             wanted: 0x06,
         });
     }
-    return Ok(());
+    Ok(())
 }
 fn get_flash_chunk_msg(payload: Vec<u8>, chunk: usize) -> BesMessage {
     let mut data_message = BesMessage {
@@ -125,10 +125,10 @@ fn get_flash_chunk_msg(payload: Vec<u8>, chunk: usize) -> BesMessage {
     let crc_value = digest.finalize();
     data_message
         .payload
-        .extend((crc_value as u32).to_le_bytes());
+        .extend(crc_value.to_le_bytes());
     data_message.payload.extend(vec![chunk as u8, 0x00, 0x00]);
     data_message.set_checksum();
-    return data_message;
+    data_message
 }
 
 fn send_flash_chunk_msg(
@@ -198,8 +198,8 @@ mod tests {
     use crate::beslink::write_flash::get_flash_chunk_msg;
 
     //Embed the bin file for future
-    const CHUNK1_TEST: &'static [u8; 32768] = include_bytes!("../../../chunk1.bin");
-    const CHUNK2_TEST: &'static [u8; 32768] = include_bytes!("../../../chunk2.bin");
+    const CHUNK1_TEST: &[u8; 32768] = include_bytes!("../../../chunk1.bin");
+    const CHUNK2_TEST: &[u8; 32768] = include_bytes!("../../../chunk2.bin");
 
     #[test]
     fn test_get_flash_chunk_msg() {

--- a/bestool/src/cmds/list_ports.rs
+++ b/bestool/src/cmds/list_ports.rs
@@ -3,12 +3,12 @@ use serialport::SerialPortType;
 pub fn cmd_list_serial_ports() {
     println!("Detected serial ports and their type:");
     fn port_type_name(t: SerialPortType) -> String {
-        return match t {
+        match t {
             SerialPortType::UsbPort(info) => format!("USB 0x{:04X}:0x{:04X}", info.vid, info.pid),
             SerialPortType::PciPort => "PCI".to_owned(),
             SerialPortType::BluetoothPort => "Bluetooth".to_owned(),
             SerialPortType::Unknown => "Unknown".to_owned(),
-        };
+        }
     }
     match serialport::available_ports() {
         Ok(ports) => {
@@ -16,6 +16,6 @@ pub fn cmd_list_serial_ports() {
                 println!("{}\t[{}]", port.port_name, port_type_name(port.port_type))
             }
         }
-        Err(e) => println!("Could not list ports due to {:?}", e),
+        Err(e) => println!("Could not list ports due to {e:?}"),
     }
 }

--- a/bestool/src/cmds/read_image.rs
+++ b/bestool/src/cmds/read_image.rs
@@ -12,8 +12,7 @@ use tracing::info;
 pub fn cmd_read_image(input_file: String, serial_port: String, start: usize, length: usize) {
     //First gain sync to the device
     println!(
-        "Reading binary data from {} @ {}",
-        serial_port, BES_PROGRAMMING_BAUDRATE
+        "Reading binary data from {serial_port} @ {BES_PROGRAMMING_BAUDRATE}"
     );
     let mut serial_port = serialport::new(serial_port, BES_PROGRAMMING_BAUDRATE);
     serial_port = serial_port.timeout(Duration::from_millis(5000));
@@ -27,7 +26,7 @@ pub fn cmd_read_image(input_file: String, serial_port: String, start: usize, len
                 error!("Failed {:?}", e);
             }
         },
-        Err(e) => println!("Failed to open serial port - {:?}", e),
+        Err(e) => println!("Failed to open serial port - {e:?}"),
     }
 }
 fn do_read_flash_data(
@@ -48,7 +47,7 @@ fn do_read_flash_data(
         };
         let chunk = do_reset_sync_read(
             serial_port,
-            0x3C000000 + start + flash_content.len(),
+            0x3C00_0000 + start + flash_content.len(),
             chunk_length,
         )?;
         flash_content.extend(chunk);
@@ -58,7 +57,7 @@ fn do_read_flash_data(
     // Write a slice of bytes to the file
     file.write_all(flash_content.as_slice())?;
 
-    return Ok(());
+    Ok(())
 }
 
 //The main bootloader wasn't super designed to allow reading the flash;
@@ -86,5 +85,5 @@ fn do_reset_sync_read(
     let flash_content = read_flash_data(serial_port, start, length)?;
     //Send reset
     send_device_reboot(serial_port)?;
-    return Ok(flash_content);
+    Ok(flash_content)
 }

--- a/bestool/src/cmds/serial_monitor.rs
+++ b/bestool/src/cmds/serial_monitor.rs
@@ -1,17 +1,14 @@
 use crate::serial_monitor::run_serial_monitor;
 
-
-pub fn cmd_serial_port_monitor(port_name:String, baud_rate:u32) {
+pub fn cmd_serial_port_monitor(port_name: String, baud_rate: u32) {
     // Span a basic serial port monitor attached to the serial port
     // Eventually we will hook in extra utility commands
-    println!("Opening serial monitor to {} @ {}", port_name,baud_rate);
-    let serial_port = serialport::new(port_name,baud_rate);
-    match serial_port.open(){
+    println!("Opening serial monitor to {port_name} @ {baud_rate}");
+    let serial_port = serialport::new(port_name, baud_rate);
+    match serial_port.open() {
         Ok(port) => {
-           let _ =  run_serial_monitor(port);
+            let _ = run_serial_monitor(port);
         }
-        Err(e) => println!("Failed to open serial port - {:?}",e),
+        Err(e) => println!("Failed to open serial port - {e:?}"),
     }
-
 }
-

--- a/bestool/src/cmds/write_image.rs
+++ b/bestool/src/cmds/write_image.rs
@@ -4,7 +4,7 @@ use crate::beslink::{
 };
 use serialport::{ClearBuffer, SerialPort};
 use std::fs;
-use std::io::Write;
+
 use std::time::Duration;
 use tracing::error;
 use tracing::info;
@@ -12,8 +12,7 @@ use tracing::info;
 pub fn cmd_write_image(input_file: String, serial_port: String) {
     //First gain sync to the device
     println!(
-        "Writing binary data to {} @ {}",
-        serial_port, BES_PROGRAMMING_BAUDRATE
+        "Writing binary data to {serial_port} @ {BES_PROGRAMMING_BAUDRATE}"
     );
     let mut serial_port = serialport::new(serial_port, BES_PROGRAMMING_BAUDRATE);
     serial_port = serial_port.timeout(Duration::from_millis(5000));
@@ -38,11 +37,10 @@ pub fn cmd_write_image(input_file: String, serial_port: String) {
                 }
                 Err(e) => {
                     error!("Failed {:?}", e);
-                    return;
                 }
             }
         }
-        Err(e) => println!("Failed to open serial port - {:?}", e),
+        Err(e) => println!("Failed to open serial port - {e:?}"),
     }
 }
 fn do_burn_image_to_flash(
@@ -51,7 +49,7 @@ fn do_burn_image_to_flash(
 ) -> Result<(), BESLinkError> {
     // Open file, read file, call burn_image_to_flash
     let file_contents = fs::read(input_file)?;
-    burn_image_to_flash(serial_port, file_contents, 0x3C000000)?;
+    burn_image_to_flash(serial_port, file_contents, 0x3C00_0000)?;
     //Send reset
     send_device_reboot(serial_port)?;
     Ok(())

--- a/bestool/src/cmds/write_image_then_monitor.rs
+++ b/bestool/src/cmds/write_image_then_monitor.rs
@@ -4,9 +4,9 @@ use crate::beslink::{
 };
 use crate::serial_monitor::run_serial_monitor;
 use serialport::{ClearBuffer, SerialPort};
-use std::error::Error;
+
 use std::fs;
-use std::io::Write;
+
 use std::time::Duration;
 use tracing::error;
 use tracing::info;
@@ -18,8 +18,7 @@ pub fn cmd_write_image_then_monitor(
 ) {
     //First gain sync to the device
     println!(
-        "Writing binary data to {} @ {}; then monitoring at {}",
-        serial_port, BES_PROGRAMMING_BAUDRATE, monitor_baud_rate
+        "Writing binary data to {serial_port} @ {BES_PROGRAMMING_BAUDRATE}; then monitoring at {monitor_baud_rate}"
     );
     let mut serial_port = serialport::new(serial_port, BES_PROGRAMMING_BAUDRATE);
     serial_port = serial_port.timeout(Duration::from_millis(5000));
@@ -61,11 +60,10 @@ pub fn cmd_write_image_then_monitor(
                 Ok(_) => {}
                 Err(e) => {
                     error!("Failed monitoring: {:?}", e);
-                    return;
                 }
             }
         }
-        Err(e) => println!("Failed to open serial port - {:?}", e),
+        Err(e) => println!("Failed to open serial port - {e:?}"),
     }
 }
 fn do_burn_image_to_flash(
@@ -75,7 +73,7 @@ fn do_burn_image_to_flash(
     // Open file, read file, call burn_image_to_flash
     let file_contents = fs::read(input_file)?;
 
-    burn_image_to_flash(serial_port, file_contents, 0x3C000000)?;
+    burn_image_to_flash(serial_port, file_contents, 0x3C00_0000)?;
     //Send reset
     send_device_reboot(serial_port)?;
     Ok(())

--- a/bestool/src/serial_monitor/mod.rs
+++ b/bestool/src/serial_monitor/mod.rs
@@ -1,4 +1,3 @@
 mod monitor;
 
-
 pub use self::monitor::run_serial_monitor;

--- a/bestool/src/serial_monitor/monitor.rs
+++ b/bestool/src/serial_monitor/monitor.rs
@@ -14,9 +14,9 @@ pub fn run_serial_monitor(mut port: Box<dyn SerialPort>) -> Result<(), Box<dyn E
             match port.read(&mut read_buffer) {
                 Ok(bytes_read) => {
                     let mut out = stdout();
-                    out.write(&read_buffer[0..min(bytes_read, BUFFER_SIZE)])?;
+                    let _ = out.write(&read_buffer[0..min(bytes_read, BUFFER_SIZE)])?;
                 }
-                Err(e) => println!("Error reading from port {:?}", e),
+                Err(e) => println!("Error reading from port {e:?}"),
             }
         } else {
             sleep(Duration::from_millis(50));


### PR DESCRIPTION
This PR runs `cargo clippy --fix` on the codebase.

It's a massive change, but still compiles. It needs testing with a set of PineBuds, as I don't have any.