### PR TITLE
Wait for port

### DIFF
--- a/bestool/Cargo.lock
+++ b/bestool/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "bestool"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "crc",

--- a/bestool/Cargo.toml
+++ b/bestool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bestool"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bestool/src/beslink/message.rs
+++ b/bestool/src/beslink/message.rs
@@ -169,7 +169,7 @@ pub fn read_message(serial_port: &mut Box<dyn SerialPort>) -> Result<BesMessage,
     }
 }
 pub fn validate_packet_checksum(packet: &[u8]) -> Result<(), BESLinkError> {
-    let checksum = calculate_message_checksum(&packet[0..packet.len()-1]);
+    let checksum = calculate_message_checksum(&packet[0..packet.len() - 1]);
     if checksum == packet[packet.len() - 1] {
         return Ok(());
     }
@@ -275,7 +275,7 @@ mod tests {
             ],
         ];
         for v in test_messages {
-	    assert!(validate_packet_checksum(&v).is_ok())
-	}
+            assert!(validate_packet_checksum(&v).is_ok())
+        }
     }
 }

--- a/bestool/src/cmds/read_image.rs
+++ b/bestool/src/cmds/read_image.rs
@@ -6,12 +6,13 @@ use crate::serial_port_opener::open_serial_port_with_wait;
 use serialport::SerialPort;
 use std::fs::File;
 use std::io::prelude::*;
+use std::path::PathBuf;
 use std::time::Duration;
 use tracing::error;
 use tracing::info;
 
 pub fn cmd_read_image(
-    input_file: &str,
+    input_file: &PathBuf,
     port_name: &str,
     start: usize,
     length: usize,
@@ -33,7 +34,7 @@ pub fn cmd_read_image(
     }
 }
 fn do_read_flash_data(
-    output_file_path: &str,
+    output_file_path: &PathBuf,
     serial_port: &mut Box<dyn SerialPort>,
     start: usize,
     length: usize,

--- a/bestool/src/cmds/read_image.rs
+++ b/bestool/src/cmds/read_image.rs
@@ -2,6 +2,7 @@ use crate::beslink::{
     helper_sync_and_load_programmer, read_flash_data, send_device_reboot, BESLinkError,
     BES_PROGRAMMING_BAUDRATE,
 };
+use crate::serial_port_opener::open_serial_port_with_wait;
 use serialport::SerialPort;
 use std::fs::File;
 use std::io::prelude::*;
@@ -9,26 +10,30 @@ use std::time::Duration;
 use tracing::error;
 use tracing::info;
 
-pub fn cmd_read_image(input_file: String, serial_port: String, start: usize, length: usize) {
+pub fn cmd_read_image(
+    input_file: &str,
+    port_name: &str,
+    start: usize,
+    length: usize,
+    wait_for_port: bool,
+) {
     //First gain sync to the device
-    println!("Reading binary data from {serial_port} @ {BES_PROGRAMMING_BAUDRATE}");
-    let mut serial_port = serialport::new(serial_port, BES_PROGRAMMING_BAUDRATE);
-    serial_port = serial_port.timeout(Duration::from_millis(5000));
+    println!("Reading binary data from {port_name} @ {BES_PROGRAMMING_BAUDRATE}");
+    let mut port = open_serial_port_with_wait(port_name, BES_PROGRAMMING_BAUDRATE, wait_for_port);
+    port.set_timeout(Duration::from_millis(5000))
+        .expect("Cant set port timeout");
 
-    match serial_port.open() {
-        Ok(mut port) => match do_read_flash_data(input_file, &mut port, start, length) {
-            Ok(_) => {
-                info!("Done...");
-            }
-            Err(e) => {
-                error!("Failed {:?}", e);
-            }
-        },
-        Err(e) => println!("Failed to open serial port - {e:?}"),
+    match do_read_flash_data(input_file, &mut port, start, length) {
+        Ok(_) => {
+            info!("Done...");
+        }
+        Err(e) => {
+            error!("Failed {:?}", e);
+        }
     }
 }
 fn do_read_flash_data(
-    output_file_path: String,
+    output_file_path: &str,
     serial_port: &mut Box<dyn SerialPort>,
     start: usize,
     length: usize,

--- a/bestool/src/cmds/serial_monitor.rs
+++ b/bestool/src/cmds/serial_monitor.rs
@@ -1,15 +1,9 @@
-use crate::serial_monitor::run_serial_monitor;
+use crate::{serial_monitor::run_serial_monitor, serial_port_opener::open_serial_port_with_wait};
 
-pub fn cmd_serial_port_monitor(port_name: String, baud_rate: u32) {
+pub fn cmd_serial_port_monitor(port_name: &str, baud_rate: u32, wait_for_port: bool) {
     // Span a basic serial port monitor attached to the serial port
     // Eventually we will hook in extra utility commands
-    println!("Opening serial monitor to {port_name} @ {baud_rate}");
-    let serial_port = serialport::new(port_name, baud_rate);
+    let port = open_serial_port_with_wait(port_name, baud_rate, wait_for_port);
 
-    match serial_port.open() {
-        Ok(port) => {
-            let _ = run_serial_monitor(port);
-        }
-        Err(e) => println!("Failed to open serial port - {e:?}"),
-    }
+    run_serial_monitor(port).unwrap();
 }

--- a/bestool/src/cmds/write_image.rs
+++ b/bestool/src/cmds/write_image.rs
@@ -2,6 +2,7 @@ use crate::beslink::{
     burn_image_to_flash, helper_sync_and_load_programmer, send_device_reboot, BESLinkError,
     BES_PROGRAMMING_BAUDRATE,
 };
+use crate::serial_port_opener::open_serial_port_with_wait;
 use serialport::{ClearBuffer, SerialPort};
 use std::fs;
 
@@ -9,40 +10,36 @@ use std::time::Duration;
 use tracing::error;
 use tracing::info;
 
-pub fn cmd_write_image(input_file: String, serial_port: String) {
+pub fn cmd_write_image(input_file: &str, port_name: &str, wait_for_port: bool) {
     //First gain sync to the device
-    println!("Writing binary data to {serial_port} @ {BES_PROGRAMMING_BAUDRATE}");
-    let mut serial_port = serialport::new(serial_port, BES_PROGRAMMING_BAUDRATE);
-    serial_port = serial_port.timeout(Duration::from_millis(5000));
+    println!("Writing binary data to {port_name} @ {BES_PROGRAMMING_BAUDRATE}");
+    let mut port = open_serial_port_with_wait(port_name, BES_PROGRAMMING_BAUDRATE, wait_for_port);
+    port.set_timeout(Duration::from_millis(5000))
+        .expect("Cant set port timeout");
 
-    match serial_port.open() {
-        Ok(mut port) => {
-            let _ = port.clear(ClearBuffer::All);
-            info!("Starting loader and checking communications");
-            match helper_sync_and_load_programmer(&mut port) {
-                Ok(_) => {
-                    info!("Done...");
-                }
-                Err(e) => {
-                    error!("Failed {:?}", e);
-                    return;
-                }
-            }
-            info!("Now doing firmware load");
-            match do_burn_image_to_flash(input_file, &mut port) {
-                Ok(_) => {
-                    info!("Done...");
-                }
-                Err(e) => {
-                    error!("Failed {:?}", e);
-                }
-            }
+    let _ = port.clear(ClearBuffer::All);
+    info!("Starting loader and checking communications");
+    match helper_sync_and_load_programmer(&mut port) {
+        Ok(_) => {
+            info!("Done...");
         }
-        Err(e) => println!("Failed to open serial port - {e:?}"),
+        Err(e) => {
+            error!("Failed {:?}", e);
+            return;
+        }
+    }
+    info!("Now doing firmware load");
+    match do_burn_image_to_flash(input_file, &mut port) {
+        Ok(_) => {
+            info!("Done...");
+        }
+        Err(e) => {
+            error!("Failed {:?}", e);
+        }
     }
 }
 fn do_burn_image_to_flash(
-    input_file: String,
+    input_file: &str,
     serial_port: &mut Box<dyn SerialPort>,
 ) -> Result<(), BESLinkError> {
     // Open file, read file, call burn_image_to_flash

--- a/bestool/src/cmds/write_image.rs
+++ b/bestool/src/cmds/write_image.rs
@@ -5,12 +5,12 @@ use crate::beslink::{
 use crate::serial_port_opener::open_serial_port_with_wait;
 use serialport::{ClearBuffer, SerialPort};
 use std::fs;
-
+use std::path::PathBuf;
 use std::time::Duration;
 use tracing::error;
 use tracing::info;
 
-pub fn cmd_write_image(input_file: &str, port_name: &str, wait_for_port: bool) {
+pub fn cmd_write_image(input_file: &PathBuf, port_name: &str, wait_for_port: bool) {
     //First gain sync to the device
     println!("Writing binary data to {port_name} @ {BES_PROGRAMMING_BAUDRATE}");
     let mut port = open_serial_port_with_wait(port_name, BES_PROGRAMMING_BAUDRATE, wait_for_port);
@@ -39,7 +39,7 @@ pub fn cmd_write_image(input_file: &str, port_name: &str, wait_for_port: bool) {
     }
 }
 fn do_burn_image_to_flash(
-    input_file: &str,
+    input_file: &PathBuf,
     serial_port: &mut Box<dyn SerialPort>,
 ) -> Result<(), BESLinkError> {
     // Open file, read file, call burn_image_to_flash

--- a/bestool/src/cmds/write_image_then_monitor.rs
+++ b/bestool/src/cmds/write_image_then_monitor.rs
@@ -8,12 +8,13 @@ use serialport::{ClearBuffer, SerialPort};
 
 use std::fs;
 
+use std::path::PathBuf;
 use std::time::Duration;
 use tracing::error;
 use tracing::info;
 
 pub fn cmd_write_image_then_monitor(
-    input_file: &str,
+    input_file_path: &PathBuf,
     serial_port: &str,
     monitor_baud_rate: u32,
     wait_for_port: bool,
@@ -38,7 +39,7 @@ pub fn cmd_write_image_then_monitor(
         }
     }
     info!("Now doing firmware load");
-    match do_burn_image_to_flash(input_file, &mut port) {
+    match do_burn_image_to_flash(input_file_path, &mut port) {
         Ok(_) => {
             info!("Done...");
         }
@@ -65,7 +66,7 @@ pub fn cmd_write_image_then_monitor(
     }
 }
 fn do_burn_image_to_flash(
-    input_file: &str,
+    input_file: &PathBuf,
     serial_port: &mut Box<dyn SerialPort>,
 ) -> Result<(), BESLinkError> {
     // Open file, read file, call burn_image_to_flash

--- a/bestool/src/main.rs
+++ b/bestool/src/main.rs
@@ -89,18 +89,16 @@ fn main() {
         BesTool::SerialMonitor(args) => {
             cmd_serial_port_monitor(&args.serial_port_path, args.baud_rate, args.wait);
         }
-        BesTool::WriteImage(args) => {
-            cmd_write_image(args.firmware_path.to_str().unwrap(), &args.port, args.wait)
-        }
+        BesTool::WriteImage(args) => cmd_write_image(&args.firmware_path, &args.port, args.wait),
         BesTool::ReadImage(args) => cmd_read_image(
-            args.firmware_path.to_str().unwrap(),
+            &args.firmware_path,
             &args.port,
             args.offset as usize,
             args.length as usize,
             args.wait,
         ),
         BesTool::WriteImageThenMonitor(args) => cmd_write_image_then_monitor(
-            args.firmware_path.to_str().unwrap(),
+            &args.firmware_path,
             &args.port,
             args.monitor_baud_rate,
             args.wait,

--- a/bestool/src/serial_port_opener.rs
+++ b/bestool/src/serial_port_opener.rs
@@ -1,0 +1,26 @@
+use std::time::Duration;
+
+use serialport::SerialPort;
+use tracing::info;
+
+pub fn open_serial_port_with_wait(
+    port_path: &str,
+    baud_rate: u32,
+    wait_for_port: bool,
+) -> Box<dyn SerialPort> {
+    // If wait for port is true, we handle it not being openable by retrying while waiting for it
+    info!("Opening {port_path} @ {baud_rate}");
+    loop {
+        let serial_port = serialport::new(port_path, baud_rate);
+        match serial_port.open() {
+            Ok(port) => return port,
+            Err(_) => {
+                //Port didnt open
+                if !wait_for_port {
+                    panic!("Unable to open requested Serial Port");
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}


### PR DESCRIPTION
# Feature

Adds `--wait` to most commands. This will make the code wait for the serial port to appear; then open it and continue.
This is useful as we want to catch devices right at boot. And some devices dont have an easy way to reset the chip, but some devices will reset chip on charger connection. So this lets you "wait" for the connection.