### PR TITLE
read-image: Clearer progress reporting

### DIFF
--- a/bestool/src/beslink/read_flash.rs
+++ b/bestool/src/beslink/read_flash.rs
@@ -14,16 +14,12 @@ pub fn read_flash_data(
     let mut result = vec![];
     let mut tries = 0;
     while result.len() < length {
-        match read_flash_chunk(serial_port, address + result.len()) {
+        let pos = address + result.len();
+        match read_flash_chunk(serial_port, pos) {
             Ok(chunk) => {
                 result.extend_from_slice(&chunk);
                 std::thread::sleep(Duration::from_millis(10)); // Try to yield to let watch dog reset
-                info!(
-                    "Read {} bytes out of {}  ({}%) from flash",
-                    result.len(),
-                    length,
-                    result.len() * 100 / length
-                );
+                info!("Read flash from 0x{:X} to 0x{:X}", pos, pos + chunk.len());
             }
             Err(e) => {
                 warn!("Error {}", e);

--- a/bestool/src/beslink/reboot.rs
+++ b/bestool/src/beslink/reboot.rs
@@ -21,7 +21,7 @@ pub fn send_device_reboot(
     device_reboot_message.set_checksum();
 
     info!(
-        "Sent device reboot message, {:?}",
+        "Sent device reboot message, {:X?}",
         device_reboot_message.to_vec()
     );
     send_message(serial_port, device_reboot_message)?;

--- a/bestool/src/cmds/read_image.rs
+++ b/bestool/src/cmds/read_image.rs
@@ -40,7 +40,7 @@ fn do_read_flash_data(
     length: usize,
 ) -> Result<(), BESLinkError> {
     let mut flash_content: Vec<u8> = vec![];
-    const MAX_READ_BEFORE_RESET: usize = 1024 * 1024; //1MB chunks
+    const MAX_READ_BEFORE_RESET: usize = 1024 * 1024; //1MiB chunks
     while flash_content.len() < length {
         let chunk_length = {
             if (length - flash_content.len()) < MAX_READ_BEFORE_RESET {
@@ -49,11 +49,15 @@ fn do_read_flash_data(
                 MAX_READ_BEFORE_RESET
             }
         };
-        let chunk = do_reset_sync_read(
-            serial_port,
-            0x3C00_0000 + start + flash_content.len(),
-            chunk_length,
-        )?;
+        let pos = 0x3C00_0000 + start + flash_content.len();
+        info!(
+        	"===== Preparing to read flash from 0x{:X} ({}%) to 0x{:X} ({}%) =====",
+            pos,
+            flash_content.len() * 100 / length,
+            pos + chunk_length,
+            (flash_content.len() + chunk_length) * 100 / length,
+        );
+        let chunk = do_reset_sync_read(serial_port, pos, chunk_length)?;
         flash_content.extend(chunk);
     }
 


### PR DESCRIPTION
cosmetic logging tweaks.
Due to periodic reboot to avoid watchdog, `read_flash_data()` only sees a partial range at a time, it's ignorant of overall progress.
Previously, to the user, progress appeared to loop:

    Read 16384 bytes out of 1048576  (1%) from flash
    ...
    Read 1048576 bytes out of 1048576  (100%) from flash

followed by boot, sync, and exactly same¹ progression several times...
(¹Unless one looks too closely into FlashRead message bytes)

As a new user, I initially assumed this is re-reading many times to ensure constistency.

Now percentages are only reported at top level, and lower-level progress uses addresses, which do advance monotonically:

    ...
    Read flash from 0x3C0FC000 to 0x3C100000
    Sent device reboot message, [190, 0, 0, 1, 241, 79]²
    Sent message type DeviceCommand [BE, 0, 0, 1, F1, 4F]²
    === Preparing to read flash from 0x3C100000 (25%) to 0x3C200000 (50%) ===
    Starting loader and checking communications
    ...
    Now doing flash read
    Read flash from 0x3C100000 to 0x3C104000
    ...
    Read flash from 0x3C1FC000 to 0x3C200000

---

²and second commit tweaks `reboot message` line to use hex like most other message logging